### PR TITLE
Correct Payload Size Calculation and Elf Header Corruption Fix

### DIFF
--- a/src/elf_patch.c
+++ b/src/elf_patch.c
@@ -126,7 +126,7 @@ struct shinfo *find_exe_seg_last_section(fmap_t *elf, size_t patch_size)
 
         /* Check if the payload is able to fit without expanding the segment past the next page boundary */
         stager_size = (uintptr_t)&g_stager_end - (uintptr_t)&g_stager;
-        if (shtable[j+1].sh_addr - shtable[j].sh_addr+shtable[j].sh_size >= patch_size+stager_size) {
+        if (shtable[j+1].sh_addr - shtable[j].sh_addr - shtable[j].sh_size >= patch_size + stager_size) {
             printf(INFO "Payload can fit on last page of RX segment\n");
             sinfo->inject_method = METHOD_LAST_PAGE_INJECT;
             goto out;

--- a/src/elf_patch.c
+++ b/src/elf_patch.c
@@ -67,12 +67,13 @@ bool expand_section(fmap_t *elf, struct shinfo *sinfo, struct tgt_info *tinfo, s
         }
     }
 
-    printf(INFO "Adjusting ELF header offsets ...\n");
-    if (ehdr->e_shoff > tinfo->base)
-        ehdr->e_shoff = ehdr->e_shoff + patch_size + stager_size;
-
-    if (ehdr->e_phoff > tinfo->base)
-        ehdr->e_phoff = ehdr->e_phoff + patch_size + stager_size;
+    if (sinfo->inject_method == METHOD_EXPAND_AND_INJECT) {
+        printf(INFO "Adjusting ELF header offsets ...\n");
+        if (ehdr->e_shoff > tinfo->base)
+            ehdr->e_shoff = ehdr->e_shoff + patch_size + stager_size;
+        if (ehdr->e_phoff > tinfo->base)
+            ehdr->e_phoff = ehdr->e_phoff + patch_size + stager_size;
+    }
 
     return true;
 }


### PR DESCRIPTION
+ Fixed the calculation for fitting the payload on last page of RX segment using one mentioned in Issue #8 
+ ELF header offsets are adjusted only if the section is really expanded, fixing Issue #7